### PR TITLE
Ignore nested node_modules directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # Node
 /node_modules
+**/node_modules/
 npm-debug.log
 yarn-error.log
 


### PR DESCRIPTION
## Summary
- remove the checked-in dependency tree under projects/lib1/node_modules
- extend the gitignore so any nested node_modules folders are ignored automatically

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0860d5180832cba507cf5d6d9f05d